### PR TITLE
Support mturk sandbox using an :endpoint_prefix option

### DIFF
--- a/lib/aws/mechanical_turk.ex
+++ b/lib/aws/mechanical_turk.ex
@@ -575,8 +575,12 @@ defmodule AWS.MechanicalTurk do
     {:error, Poison.Parser.t} |
     {:error, HTTPoison.Error.t}
   defp request(client, action, input, options) do
+
+    prefix = Keyword.get(options, :endpoint_prefix, "mturk-requester")
+    options = Keyword.delete(options, :endpoint_prefix)
     client = %{client | service: "mturk-requester"}
-    host = get_host("mturk-requester", client)
+    host = get_host(prefix, client)
+
     url = get_url(host, client)
     headers = [{"Host", host},
                {"Content-Type", "application/x-amz-json-1.1"},


### PR DESCRIPTION
The endpoint for mturk is composed by a prefix (`mturk-requester`), the region (e.g., `us-east-1`) and aws-elixir client's endpoint (e.g., `amazonaws.com`). 

Since mturk supports a sandboxed mode, the final endpoint is slightly different with a prefix of `mturk-requester-sandbox`.

This PR makes it possible to pass an optional endpoint prefix (`:endpoint_prefix`) in mturk's calls. E.g.:

```
AWS.MechanicalTurk.list_h_i_ts(client, %{}, endpoint_prefix: "mturk-requester-sandbox")
```

By default the prefix is set as the previously used `mturk-requester`.