### PR TITLE
Update Httpoison to v1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule AWS.Mixfile do
     [{:dialyxir, "~> 0.5.0", only: [:dev]},
      {:earmark, "~> 1.1", only: [:dev]},
      {:ex_doc, "~> 0.15.0", only: [:dev]},
-     {:httpoison, "~> 0.11.1"},
+     {:httpoison, "~> 1.0"},
      {:poison, "~> 3.1"},
      {:timex, "~> 3.1"}]
   end


### PR DESCRIPTION
I'd ideally like to use v1 of Httpoison and this library in my app but the two sets of dependencies are incompatible