### PR TITLE
Remove "Docs" link from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,6 @@ defmodule AWS.Mixfile do
     [maintainers: ["Jamu Kakar"],
      licenses: ["Apache 2.0"],
      links: %{"GitHub" => "https://github.com/aws-beam/aws-elixir",
-              "Docs" => "http://hexdocs.pm/aws/#{@version}/",
               "Changelog" => "https://github.com/aws-beam/aws-elixir/blob/master/CHANGELOG.md"}]
   end
 end


### PR DESCRIPTION
Hex.pm already automatically adds an "Online documentation" link.