### PR TITLE
normalize query string when signing

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -238,11 +238,27 @@ defmodule AWS.Request.Internal do
 
   @doc """
   Strip the query string from the URL, if one if present, and return the URL
-  and query string as separate values.
+  and the normalized query string as separate values.
   """
   def split_url(url) do
     url = URI.parse(url)
-    {url.path, url.query}
+    {url.path, normalize_query(url.query)}
+  end
+
+  @doc """
+  Sort query params by name first, then by value (if present). Append "=" to
+  params with missing value.
+  Example: "foo=bar&baz" becomes "baz=&foo=bar"
+  """
+  def normalize_query(nil), do: ""
+
+  def normalize_query(""), do: ""
+
+  def normalize_query(query) do
+    query
+    |> String.split("&")
+    |> Enum.sort_by(&String.split(&1, "="))
+    |> Enum.map_join("&", &if(String.contains?(&1, "="), do: &1, else: "#{&1}="))
   end
 
   @doc """

--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -257,8 +257,12 @@ defmodule AWS.Request.Internal do
   def normalize_query(query) do
     query
     |> String.split("&")
-    |> Enum.sort_by(&String.split(&1, "="))
-    |> Enum.map_join("&", &if(String.contains?(&1, "="), do: &1, else: "#{&1}="))
+    |> Enum.map(&String.split(&1, "="))
+    |> Enum.sort()
+    |> Enum.map_join("&", fn
+         [key, value] -> key <> "=" <> value
+         [key] -> key <> "="
+       end)
   end
 
   @doc """

--- a/test/aws/request_test.exs
+++ b/test/aws/request_test.exs
@@ -131,9 +131,9 @@ defmodule AWS.Request.InternalTest do
                                             "us-east-1", "s3")
   end
 
-  test "split_url/1 splits a URL from its query string, URL encodes the query string, and returns the URL and query string as separate values" do
-    expected = {"/index", "one=1&two=2"}
-    actual = Internal.split_url("https://example.com/index?one=1&two=2")
+  test "split_url/1 transforms a URL into {path, normalized_query_string}" do
+    expected = {"/index", "none=&one=1&two=2"}
+    actual = Internal.split_url("https://example.com/index?two=2&none&one=1")
     assert expected == actual
   end
 


### PR DESCRIPTION
As per
https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

NOTE: "=" chars in the param values are still not double encoded