### PR TITLE
Fix HEAD requests for default HTTPClient implementation

### DIFF
--- a/lib/aws/http_client.ex
+++ b/lib/aws/http_client.ex
@@ -38,7 +38,10 @@ defmodule AWS.HTTPClient do
       {:ok, status_code, response_headers, body} ->
         {:ok, %{status_code: status_code, headers: response_headers, body: body}}
 
-      error ->
+      {:ok, status_code, response_headers} ->
+        {:ok, %{status_code: status_code, headers: response_headers, body: ""}}
+
+      {:error, _error} = error ->
         error
     end
   end

--- a/test/aws/client_test.exs
+++ b/test/aws/client_test.exs
@@ -35,7 +35,7 @@ defmodule AWS.ClientTest do
       {:ok, bypass: bypass}
     end
 
-    test "sends request to HTTP server", %{client: client, bypass: bypass} do
+    test "sends a POST request to HTTP server", %{client: client, bypass: bypass} do
       headers = [{"authorization", "Bearer 123"}, {"content-type", "application/json"}]
       expected_body = "{\"data\": \"ok\"}"
 
@@ -46,6 +46,18 @@ defmodule AWS.ClientTest do
 
       result = AWS.Client.request(client, :post, "#{url(bypass)}/publish", "", headers)
       assert {:ok, %{status_code: 200, body: ^expected_body}} = result
+    end
+
+    test "sends a HEAD request to HTTP server", %{client: client, bypass: bypass} do
+      headers = [{"authorization", "Bearer 123"}, {"content-type", "application/json"}]
+
+      Bypass.expect_once(bypass, "HEAD", "/head_object", fn conn ->
+        assert true == Enum.all?(headers, fn header -> Enum.member?(conn.req_headers, header) end)
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      result = AWS.Client.request(client, :head, "#{url(bypass)}/head_object", "", headers)
+      assert {:ok, %{status_code: 200, body: ""}} = result
     end
   end
 


### PR DESCRIPTION
The default implementation uses hackney, which does not return "body"
when a request is using the HEAD HTTP verb.
We now return a empty string to match with the specs of the client.

This fixes https://github.com/aws-beam/aws-elixir/issues/59