### PR TITLE
Fix handle of successful HTTP status from requests

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -97,8 +97,8 @@ defmodule AWS.Request do
 
     case Client.request(client, method, url, payload, headers, options) do
       {:ok, %{status_code: status_code, body: body} = response}
-      when is_nil(success_status_code) and status_code in [200, 202, 204]
-      when status_code == success_status_code ->
+      when (is_nil(success_status_code) and status_code in 200..299) or
+             status_code == success_status_code ->
         body =
           if body != "" do
             {receive_body_as_binary?, _options} = Keyword.pop(options, :receive_body_as_binary?)


### PR DESCRIPTION
This commit fixes the way we treat successful HTTP code from responses.
It allows any successful code (200..299), but requires the exact code if
provided by the specs.

This fixes some cases were the API returns a code above the expected.
An example of this can be found in: https://github.com/philss/aws-s3-stream-download-poc/blob/main/lib/download_manager.ex#L57