### PR TITLE
Change application name to "aws_elixir"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule AWS.Mixfile do
 
   def project do
     [
-      app: :aws,
+      app: :aws_elixir,
       description: "AWS clients for Elixir",
       package: package(),
       version: @version,
@@ -22,22 +22,10 @@ defmodule AWS.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type `mix help compile.app` for more information
   def application do
     [extra_applications: [:logger, :crypto, :xmerl, :eex]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type `mix help deps` for more examples and options
   defp deps do
     [
       {:dialyxir, "~> 0.5.0", only: [:dev]},


### PR DESCRIPTION
This is needed to avoid conflicts with aws-erlang's application name.

It solves https://github.com/aws-beam/aws-codegen/issues/73