### PR TITLE
add query params to base request url that has existing params

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -178,7 +178,8 @@ defmodule AWS.Request do
 
   defp add_query(url, query, client) do
     querystring = Client.encode!(client, query, :query)
-    "#{url}?#{querystring}"
+    joiner = if String.contains?(url, "?"), do: "&", else: "?"
+    "#{url}#{joiner}#{querystring}"
   end
 
   defp encode!(%Client{} = client, protocol, payload) when protocol in @valid_protocols and is_map(payload) do

--- a/test/aws/request_test.exs
+++ b/test/aws/request_test.exs
@@ -122,6 +122,45 @@ defmodule AWS.RequestTest do
       [client: client, metadata: metadata]
     end
 
+    test "send get request with params", %{client: client, metadata: metadata} do
+      assert {:ok, _response, _http_response} =
+               Request.request_rest(
+                 client,
+                 metadata,
+                 :get,
+                 "/foo/bar",
+                 [{"q", "x&y="}, {"size", 5}],
+                 [],
+                 nil,
+                 [],
+                 nil
+               )
+
+      assert_receive {:request, :get, url, _body, _headers, _options}
+
+      assert url == "https://mobileanalytics.us-east1.amazonaws.com:443/foo/bar?q=x%26y%3D&size=5"
+    end
+
+    test "send get request to url_path with params", %{client: client, metadata: metadata} do
+      assert {:ok, _response, _http_response} =
+               Request.request_rest(
+                 client,
+                 metadata,
+                 :get,
+                 "/foo/bar?format=sdk&pretty=true",
+                 [{"q", "x&y="}, {"size", 5}],
+                 [],
+                 nil,
+                 [],
+                 nil
+               )
+
+      assert_receive {:request, :get, url, _body, _headers, _options}
+
+      assert url ==
+               "https://mobileanalytics.us-east1.amazonaws.com:443/foo/bar?format=sdk&pretty=true&q=x%26y%3D&size=5"
+    end
+
     test "send post request", %{client: client, metadata: metadata} do
       assert {:ok, response, http_response} =
                Request.request_rest(


### PR DESCRIPTION
The base `url_path` generated for API requests to several AWS services sometimes actually includes query params itself. This is true especially for S3, where the `url_path` for nearly all its GET requests includes a query param. For example, the `url_path` generated for `AWS.S3.list_objects_v2/12` is this:

```
    url_path = "/#{URI.encode(bucket)}?list-type=2"
```

When a request to such an API also includes additional query params, those query params currently are always joined to the base path with another `?`, like so:

```
https://s3.us-east-1.amazonaws.com:443/mybucket?list-type=2?delimiter=%2F
```

This results in an error like the following:

```
iex> AWS.S3.list_objects_v2(myclient, "mybucket", nil, "/")
** (FunctionClauseError) no function clause matching in anonymous fn/1 in AWS.Request.Internal.normalize_query/1

    The following arguments were given to anonymous fn/1 in AWS.Request.Internal.normalize_query/1:

        # 1
        ["list-type", "2?delimiter", "%2F"]

    (aws 0.7.0) lib/aws/request.ex:466: anonymous fn/1 in AWS.Request.Internal.normalize_query/1
    (elixir 1.11.3) lib/enum.ex:1508: anonymous fn/2 in Enum.map_join/3
    (elixir 1.11.3) lib/enum.ex:3449: Enum.map_intersperse_list/3
    (elixir 1.11.3) lib/enum.ex:1508: Enum.map_join/3
    (aws 0.7.0) lib/aws/request.ex:449: AWS.Request.Internal.split_url/1
    (aws 0.7.0) lib/aws/request.ex:398: AWS.Request.Internal.canonical_request/4
    (aws 0.7.0) lib/aws/request.ex:228: AWS.Request.sign_v4/6
    (aws 0.7.0) lib/aws/request.ex:94: AWS.Request.request_rest/9
```

This change checks the base url before joining additional query params to see if the url already contains a `?` -- if so, it joins the query params with a `&` instead of a `?`.
