### PR TITLE
Fix build of URL when has existing query params

### DIFF
--- a/test/aws/request_test.exs
+++ b/test/aws/request_test.exs
@@ -122,6 +122,43 @@ defmodule AWS.RequestTest do
       [client: client, metadata: metadata]
     end
 
+    test "send get request with params", %{client: client, metadata: metadata} do
+      assert {:ok, _response, _http_response} =
+               Request.request_rest(
+                 client,
+                 metadata,
+                 :get,
+                 "/foo/bar",
+                 [{"q", "x&y="}, {"size", 5}],
+                 [],
+                 nil,
+                 [],
+                 nil
+               )
+
+      assert_receive {:request, :get, url, _body, _headers, _options}
+
+      assert url == "https://mobileanalytics.us-east1.amazonaws.com/foo/bar?q=x%26y%3D&size=5"
+
+      assert {:ok, _response, _http_response} =
+               Request.request_rest(
+                 client,
+                 metadata,
+                 :get,
+                 "/foo/bar?format=sdk&pretty=true",
+                 [{"q", "x&y="}, {"size", 5}],
+                 [],
+                 nil,
+                 [],
+                 nil
+               )
+
+      assert_receive {:request, :get, url, _body, _headers, _options}
+
+      assert url ==
+               "https://mobileanalytics.us-east1.amazonaws.com/foo/bar?format=sdk&pretty=true&q=x%26y%3D&size=5"
+    end
+
     test "send post request", %{client: client, metadata: metadata} do
       assert {:ok, response, http_response} =
                Request.request_rest(
@@ -141,7 +178,7 @@ defmodule AWS.RequestTest do
 
       assert_receive {:request, :post, url, body, headers, options}
 
-      assert url == "https://mobileanalytics.us-east1.amazonaws.com:443/foo/bar"
+      assert url == "https://mobileanalytics.us-east1.amazonaws.com/foo/bar"
       assert body == "{\"Body\":\"data\"}"
 
       header_names = Enum.map(headers, fn {header_name, _} -> header_name end)


### PR DESCRIPTION
This fixes a bug when building the query params of the URL if the base
URL already has query string params.

Based on https://github.com/aws-beam/aws-elixir/pull/69

Co-authored-by: Justin Ludwig <justin@ldwg.us>