### PR TITLE
Switch to :crypto.mac/4 from :crypto.hmac/3

### DIFF
--- a/lib/aws/util.ex
+++ b/lib/aws/util.ex
@@ -5,7 +5,7 @@ defmodule AWS.Util do
   Create an HMAC-SHA256 for `key` and `message`.
   """
   def hmac_sha256(key, message) do
-    :crypto.hmac(:sha256, key, message)
+    :crypto.mac(:hmac, :sha256, key, message)
   end
 
   @doc """

--- a/lib/aws/util.ex
+++ b/lib/aws/util.ex
@@ -4,8 +4,14 @@ defmodule AWS.Util do
   @doc """
   Create an HMAC-SHA256 for `key` and `message`.
   """
-  def hmac_sha256(key, message) do
-    :crypto.mac(:hmac, :sha256, key, message)
+  if System.otp_release() >= "22" do
+    def hmac_sha256(key, message) do
+      :crypto.mac(:hmac, :sha256, key, message)
+    end
+  else
+    def hmac_sha256(key, message) do
+      :crypto.hmac(:sha256, key, message)
+    end
   end
 
   @doc """


### PR DESCRIPTION
:crypto.hmac/3 is deprecated since OTP 22

See https://erlang.org/doc/general_info/deprecations.html for more info.
