### PR TITLE
Update CI to use ErlEF Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
               otp: 21.3.8.17
           - pair:
               elixir: 1.11.4
-              otp: 23.3.3
+              otp: "24.0"
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,55 @@
-name: Build
+name: CI
+
 on:
+  pull_request:
   push:
     branches:
-      - '*'
-  pull_request:
-    branches:
       - master
+
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-18.04
+    env:
+      MIX_ENV: test
     strategy:
+      fail-fast: false
       matrix:
-        platform: [ubuntu-latest]
-        elixir: ['1.8.2', '1.9.4', '1.10.4']
-    runs-on: ${{ matrix.platform }}
-    container:
-      image: elixir:${{ matrix.elixir }}-slim
+        include:
+          - pair:
+              elixir: 1.7.4
+              otp: 21.3.8.17
+          - pair:
+              elixir: 1.11.4
+              otp: 23.3.3
+            lint: lint
     steps:
       - uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: mix-${{ runner.os }}-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            mix-${{ runner.os }}-
+
       - run: mix deps.get
+
+      - run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+
+      - run: mix deps.unlock --check-unused
+        if: ${{ matrix.lint }}
+
+      - run: mix deps.compile
+
+      - run: mix compile --warnings-as-errors
+        if: ${{ matrix.lint }}
+
       - run: mix test

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule AWS.Mixfile do
       name: "aws-elixir",
       source_url: @repo_url,
       homepage_url: @repo_url,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       docs: docs(),
@@ -22,22 +22,10 @@ defmodule AWS.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type `mix help compile.app` for more information
   def application do
     [extra_applications: [:logger, :crypto, :xmerl, :eex]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type `mix help deps` for more examples and options
   defp deps do
     [
       {:dialyxir, "~> 0.5.0", only: [:dev]},


### PR DESCRIPTION
It keeps easier to configure and update versions of OTP and Elixir.
We are using the older supported version and the latest one.
Also, this bumps Elixir requirement to match our build.