### PR TITLE
Fix default content-type for binary payload requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ iex> AWS.S3.put_object(client, "your-bucket-name", "foo/your-file-on-s3.txt",
   %{"Body" => file, "ContentMD5" => md5})
 ```
 
+Note that you may need to specify the `ContentType` attribute when calling `AWS.S3.put_object/4`.
+This is because S3 will use that to store the MIME type of the file.
+
+Remember to check the operation documentation for details:
+[https://docs.aws.amazon.com/](https://docs.aws.amazon.com/)
+
 ## Installation
 
 Add `:aws` to your list of dependencies in `mix.exs`. It also requires

--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -83,10 +83,19 @@ defmodule AWS.Request do
       |> add_query(query, client)
       |> to_string()
 
-    additional_headers = [{"Host", host}, {"Content-Type", metadata.content_type}]
-    headers = add_headers(additional_headers, headers)
-
     {send_body_as_binary?, options} = Keyword.pop(options, :send_body_as_binary?)
+
+    # It will assume the default as "application/octet-stream" if is sending body
+    # as binary and the input does not specify the `Content-type`.
+    default_content_type =
+      if send_body_as_binary? do
+        "application/octet-stream"
+      else
+        metadata.content_type
+      end
+
+    additional_headers = [{"Host", host}, {"Content-Type", default_content_type}]
+    headers = add_headers(additional_headers, headers)
 
     payload =
       if send_body_as_binary? do
@@ -267,7 +276,7 @@ defmodule AWS.Request do
     end
   end
 
-  defp now() do
+  defp now do
     NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
   end
 end

--- a/test/aws/protocol_tests/rest_json_test.exs
+++ b/test/aws/protocol_tests/rest_json_test.exs
@@ -108,7 +108,7 @@ defmodule AWS.ProtocolTests.RestJSONTest do
 
       Bypass.expect(bypass, fn conn ->
         [content_type] = Plug.Conn.get_req_header(conn, "content-type")
-        assert content_type == metadata.content_type
+        assert content_type == "application/octet-stream"
 
         {:ok, body, conn} = Plug.Conn.read_body(conn)
 


### PR DESCRIPTION
This is needed to avoid setting a wrong MIME type for an uploaded
document, mainly using the S3 API.

This fixes https://github.com/aws-beam/aws-elixir/issues/68