### PR TITLE
Require Elixir v1.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.7.4
-              otp: "21.3.8.17"
+              elixir: "1.10.4"
+              otp: "21.3.8.19"
           - pair:
               elixir: "1.12.2"
               otp: "24.0.3"

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule AWS.Mixfile do
       app: :aws,
       version: @version,
       name: "aws-elixir",
-      elixir: "~> 1.7",
+      elixir: "~> 1.10",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       package: package(),


### PR DESCRIPTION
The idea is to adopt a policy of supporting the last 3 minor Elixir
versions.