### PR TITLE
Missing `region` in `AWS.Client.t/0`

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -56,6 +56,7 @@ defmodule AWS.Client do
           access_key_id: binary() | nil,
           secret_access_key: binary() | nil,
           session_token: binary() | nil,
+          region: binary() | nil,
           service: binary() | nil,
           endpoint: endpoint_config(),
           proto: binary(),


### PR DESCRIPTION
The `t` type definition is missing `region` and cannot be used in `@spec` if the function returns an `%AWS.Client{}` struct.