### PR TITLE
Don't display acess_key_id and secret_access_key

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -33,6 +33,7 @@ defmodule AWS.Client do
   The `service` option is overwritten by each service with its signing name from metadata.
   """
 
+  @derive {Inspect, except: [:access_key_id, :secret_access_key]}
   defstruct access_key_id: nil,
             secret_access_key: nil,
             session_token: nil,


### PR DESCRIPTION
They are considered sensitive values and should not be displayed (they could end up in logs).

Deriving Inspect protocol documentation: https://hexdocs.pm/elixir/1.12/Inspect.html#module-deriving.