### PR TITLE
Document backward incompatible changes on 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ the majority of AWS services.
 - Handle querystring parameters.
 - Allow the user to configure the HTTP client, as well as the JSON parser.
 
+### Backwards Incompatible Changed
+- Update structure of error response from `{:error, {exception, reason}}` to `{:error, {:unexpected_response, response}}`.
+  - You can obtained the previous `exception` and `reason` in this version by decoding the `response.body`, where `exception` is mapped to `response.body["__type"]` and `reason` is mapped to `response.body["message"]`.
+- Update module naming for certain AWS services. E.g.:
+  - `AWS.Cognito` is renamed to `AWS.CognitoIdentity`  
+  - `AWS.Cognito.IdentityProvider` is renamed to `AWS.CognitoIdentityProvider`
+
 ### Changed
 - Improve documentation by using more markdown and removing HTML tags.
 - Rename modules and function names to consider the correct use of abbreviations, like SQS or DB.
@@ -73,6 +80,8 @@ is an optional dependency.
 is an example).
 - Normalize querystring when signing.
 - Remove duplicated headers.
+
+
 
 ## [v0.6.0] - 2020-08-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,6 @@ is an example).
 - Normalize querystring when signing.
 - Remove duplicated headers.
 
-
-
 ## [v0.6.0] - 2020-08-20
 ### Added
 - Includes support for more AWS APIs.


### PR DESCRIPTION
Address #101. 

On top of the reported backward incompatible change, also include the documentation for changes result in different Module naming on `0.7.0` onward.