### PR TITLE
Update `endpoint_config` type

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -51,7 +51,7 @@ defmodule AWS.Client do
 
   Check `put_endpoint/2` for more details.
   """
-  @type endpoint_config :: binary() | {:keep_prefixes, binary()} | (map() -> binary())
+  @type endpoint_config :: binary() | {:keep_prefixes, binary()} | (map() -> binary()) | nil
 
   @type t :: %__MODULE__{
           access_key_id: binary() | nil,


### PR DESCRIPTION
The `AWS.Client.create/3` function returns an `AWS.Client` struct with `endpoint` as a `nil` value.

I guess we can safely type the `endpoint` type as _nullable_ in this case.

See a screenshot of the success typing after calling  `AWS.Client.create/3`.

<img width="308" alt="image" src="https://user-images.githubusercontent.com/489004/146404094-a215285c-c628-46fd-a16b-5c014e7a054f.png">
