### PR TITLE
Isolate connection pool used by AWS

### DIFF
--- a/lib/aws/http_client.ex
+++ b/lib/aws/http_client.ex
@@ -29,10 +29,12 @@ defmodule AWS.HTTPClient do
               {:ok, %{status_code: integer(), headers: [{binary(), binary()}], body: binary()}}
               | {:error, term()}
 
+  @hackney_pool_name :aws_pool
+
   def request(method, url, body, headers, options) do
     ensure_hackney_running!()
 
-    options = [:with_body | options]
+    options = [:with_body | options] |> Keyword.put_new(:pool, @hackney_pool_name)
 
     case :hackney.request(method, url, headers, body, options) do
       {:ok, status_code, response_headers, body} ->


### PR DESCRIPTION
Use a named connection pool on built-in hackney implementation, so all requests made by this library will be isolated.

As this library doesn't define any application or supervision tree, the connection pool will be initiated lazily by hackney itself on the first call. It can be still be overwritten, so users could create pools per AWS service or more complicated needs.