### PR TITLE
Don't display session_token

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -33,7 +33,7 @@ defmodule AWS.Client do
   The `service` option is overwritten by each service with its signing name from metadata.
   """
 
-  @derive {Inspect, except: [:access_key_id, :secret_access_key]}
+  @derive {Inspect, except: [:access_key_id, :secret_access_key, :session_token]}
   defstruct access_key_id: nil,
             secret_access_key: nil,
             session_token: nil,


### PR DESCRIPTION
As a follow-up of #100, in which I forgot to add `:session_token`.
Even though it's a short-lived secret, it's better to not display `:session_token` when inspecting an AWS.Client as it could end up in logs.