### PR TITLE
Update aws_signature to 0.3.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule AWS.Mixfile do
 
   defp deps do
     [
-      {:aws_signature, "~> 0.1.0"},
+      {:aws_signature, "~> 0.3.0"},
       {:jason, "~> 1.2"},
       {:dialyxir, "~> 1.1.0", only: [:dev], runtime: false},
       {:earmark, "~> 1.4", only: [:dev]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "aws_signature": {:hex, :aws_signature, "0.1.1", "3f678b5e2b0a05fbb3b9279bff6576404a94d91b1d47091ae302fb392dcf9db4", [:rebar3], [], "hexpm", "7292ff4a123e1e32d37c2914e855870baeee51b18c3c7adf5708fe54bef1808f"},
+  "aws_signature": {:hex, :aws_signature, "0.3.1", "67f369094cbd55ffa2bbd8cc713ede14b195fcfb45c86665cd7c5ad010276148", [:rebar3], [], "hexpm", "50fc4dc1d1f7c2d0a8c63f455b3c66ecd74c1cf4c915c768a636f9227704a674"},
   "bypass": {:hex, :bypass, "2.1.0", "909782781bf8e20ee86a9cabde36b259d44af8b9f38756173e8f5e2e1fabb9b1", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "d9b5df8fa5b7a6efa08384e9bbecfe4ce61c77d28a4282f79e02f1ef78d96b80"},
   "certifi": {:hex, :certifi, "2.8.0", "d4fb0a6bb20b7c9c3643e22507e42f356ac090a1dcea9ab99e27e0376d695eba", [:rebar3], [], "hexpm", "6ac7efc1c6f8600b08d625292d4bbf584e14847ce1b6b5c44d983d273e1097ea"},
   "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},


### PR DESCRIPTION
It looks like only the `AWS.Signature` uses the `aws_signature` package, and only the `sign_v4` function which seems to maintain it's function signature between the versions.

However it would be nice to be able to use this package along with the new options in `sign_v4_query_params/8`.