### PR TITLE
Fix query string encoding for lists and map values

### DIFF
--- a/lib/aws/util.ex
+++ b/lib/aws/util.ex
@@ -20,11 +20,47 @@ defmodule AWS.Util do
   end
 
   @doc """
-  Encode map into querystring.
+  Encode a map or pairs of values into a querystring.
+
+  This is going to work recursively if the value is a list or another map.
+
+  ## Examples
+
+      iex> input = %{"Action" => "OperationName", "Bar" => "val1", "Foo" => 42}
+      iex> AWS.Util.encode_query(input)
+      "Action=OperationName&Bar=val1&Foo=42"
+
+      iex> input = [{"Action", "OperationName"}, {"Bar", "val1"}, {"Foo", 42}]
+      iex> AWS.Util.encode_query(input)
+      "Action=OperationName&Bar=val1&Foo=42"
+
+      iex> input = %{"Action" => "OperationName", "Bar" => ["val1", "val2"], "Foo" => 42}
+      iex> AWS.Util.encode_query(input)
+      "Action=OperationName&Bar.1=val1&Bar.2=val2&Foo=42"
+
+      iex> input = %{"Action" => "OperationName", "Bar" => %{"Baz" => ["val1", "val2"]}, "Foo" => 42}
+      iex> AWS.Util.encode_query(input)
+      "Action=OperationName&Bar.Baz.1=val1&Bar.Baz.2=val2&Foo=42"
+
   """
-  def encode_query(value) do
-    value
-    |> Enum.map(fn {k, v} -> {k, to_string(v)} end)
+  def encode_query(input) do
+    input
+    |> Enum.map(&encode_query_value/1)
+    |> List.flatten()
     |> :uri_string.compose_query()
   end
+
+  defp encode_query_value({key, value}) when is_list(value) do
+    value
+    |> Enum.with_index(1)
+    |> Enum.map(fn {inner_value, idx} ->
+      encode_query_value({[key, ?., to_string(idx)], inner_value})
+    end)
+  end
+
+  defp encode_query_value({key, %{} = map_value}) do
+    for {k, v} <- map_value, do: encode_query_value({[key, ?., to_string(k)], v})
+  end
+
+  defp encode_query_value({key, value}), do: {IO.chardata_to_string(key), to_string(value)}
 end

--- a/test/aws/util_test.exs
+++ b/test/aws/util_test.exs
@@ -1,6 +1,8 @@
 defmodule AWS.UtilTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
   alias AWS.Util
+  doctest(Util)
 
   test "encode_multi_segment_uri/1" do
     assert Util.encode_multi_segment_uri("/my$key") == "/my%24key"
@@ -10,5 +12,54 @@ defmodule AWS.UtilTest do
   test "encode_uri/1" do
     assert Util.encode_uri("/my$key") == "%2Fmy%24key"
     assert Util.encode_uri("/h!") == "%2Fh%21"
+  end
+
+  describe "encode_query/1" do
+    test "with a basic input" do
+      input = %{
+        "Action" => "OperationName",
+        "Bar" => 42,
+        "Debit" => 1256.74,
+        "Foo" => :val1,
+        "Version" => "2014-01-01"
+      }
+
+      assert Util.encode_query(input) ==
+               "Action=OperationName&Bar=42&Debit=1256.74&Foo=val1&Version=2014-01-01"
+    end
+
+    test "with a list of strings as key value" do
+      input = %{
+        "Action" => "OperationName",
+        "Operations" => ["foo", "bar"]
+      }
+
+      assert Util.encode_query(input) ==
+               "Action=OperationName&Operations.1=foo&Operations.2=bar"
+    end
+
+    test "with a map with string values" do
+      input = %{
+        "Action" => "OperationName",
+        "Operation" => %{"name" => "foo", "state" => "bar"}
+      }
+
+      assert Util.encode_query(input) ==
+               "Action=OperationName&Operation.name=foo&Operation.state=bar"
+    end
+
+    test "with a list of maps with strings and lists" do
+      input = %{
+        "Action" => "OperationName",
+        "Operation" => [
+          %{"name" => "foo", "state" => "bar"},
+          %{"name" => "baz", "state" => "full"},
+          %{"other" => ["a", "b", "c"]}
+        ]
+      }
+
+      assert Util.encode_query(input) ==
+               "Action=OperationName&Operation.1.name=foo&Operation.1.state=bar&Operation.2.name=baz&Operation.2.state=full&Operation.3.other.1=a&Operation.3.other.2=b&Operation.3.other.3=c"
+    end
   end
 end


### PR DESCRIPTION
This fix enables complex inputs, like when sending a batch to SQS.

Closes https://github.com/aws-beam/aws-elixir/issues/141