### PR TITLE
XML attributes, XML boolean, route53 example

### DIFF
--- a/examples/route53/change_rr.ex
+++ b/examples/route53/change_rr.ex
@@ -1,0 +1,49 @@
+
+defmodule Example.Route53 do
+  @xmlns "https://route53.amazonaws.com/doc/2013-04-01/"
+  def update_rr(client, zoneid, changes) do
+    req_payload = %{
+      {"ChangeResourceRecordSetsRequest", %{xmlns: @xmlns}} => %{
+        "ChangeBatch" => %{
+          "Comment" => "add ip",
+          "Changes" => [
+            %{
+              "Change" =>
+                Enum.map(changes, fn change ->
+                  %{
+                    "Action" => change.action,
+                    "ResourceRecordSet" => %{
+                      "Name" => change.name,
+                      "Type" => change.type,
+                      "TTL" => change.ttl,
+                      "ResourceRecords" => %{
+                        "ResourceRecord" =>
+                          Enum.map(change.records, fn value ->
+                            %{"Value" => value}
+                          end)
+                      }
+                    }
+                  }
+                end)
+            }
+          ]
+        }
+      }
+    }
+
+    AWS.Route53.change_resource_record_sets(client, zoneid, req_payload)
+  end
+
+  def go() do
+    client = AWS.Client.create("us-east-1")
+    zoneid = "ZZZZZZ"
+    fqdn = "sub.example.com"
+    new_iplist = ["127.0.0.1", "127.0.0.2"]
+
+    changes = [
+      %{action: "UPSERT", name: fqdn, type: "A", ttl: 300, records: new_iplist}
+    ]
+
+    update_rr(client, zoneid, changes)
+  end
+end

--- a/lib/aws/xml.ex
+++ b/lib/aws/xml.ex
@@ -61,10 +61,38 @@ defmodule AWS.XML do
     ["<", k, ">", Float.to_charlist(v), "</", k, ">"]
   end
 
+  defp encode_xml_key_value({k, v}) when is_binary(k) and is_boolean(v) do
+    ["<", k, ">", to_string(v), "</", k, ">"]
+  end
+
   defp encode_xml_key_value({k, v}) when is_binary(k) and is_map(v) do
     [
       "<",
       k,
+      ">",
+      v
+      |> Map.to_list()
+      |> Enum.map(&encode_xml_key_value/1),
+      "</",
+      k,
+      ">"
+    ]
+  end
+
+  # allow passing a map to use as xml attributes
+  defp encode_xml_key_value({{k, attrmap}, v})
+       when is_binary(k) and is_map(attrmap) and is_map(v) do
+    # note: assume that special chars in av are quoted by caller
+    attrlist =
+      for {a, av} <- attrmap do
+        [" ", to_string(a), "=", "\"#{av}\""]
+      end
+      |> List.flatten()
+
+    [
+      "<",
+      k,
+      attrlist,
       ">",
       v
       |> Map.to_list()

--- a/test/aws/xml_test.exs
+++ b/test/aws/xml_test.exs
@@ -45,4 +45,27 @@ defmodule AWS.XMLTest do
 
     assert ^expected = AWS.XML.decode!(input)
   end
+
+  test "encode_to_iodata!/2 test all possible types" do
+    input = %{
+      {"TagWithAttrs", %{xmlns: "some-ns"}} => %{
+        "TagWithOutAttrs" => %{
+          "TestTypes" => [
+            %{"BoolVal" => true},
+            %{"IntVal" => 1},
+            %{"FloatVal" => 1.0},
+            %{"BinValue" => "hello"}
+          ]
+        }
+      }
+    }
+
+    expected =
+      """
+      <TagWithAttrs xmlns="some-ns"><TagWithOutAttrs><TestTypes><BoolVal>true</BoolVal></TestTypes><TestTypes><IntVal>1</IntVal></TestTypes><TestTypes><FloatVal>1.0</FloatVal></TestTypes><TestTypes><BinValue>hello</BinValue></TestTypes></TagWithOutAttrs></TagWithAttrs>
+      """
+      |> String.trim()
+
+    assert expected == AWS.XML.encode_to_iodata!(input)
+  end
 end


### PR DESCRIPTION

* Added ability to pass a map to be used as XML attributes, needed for route53 api payload
* Added XML generation for boolean type
* Added examples directory with route53/change_rr.ex as first file