### PR TITLE
Add `host_prefix` to request endpoint when available

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -184,12 +184,22 @@ defmodule AWS.Request do
       %{global?: true, endpoint: endpoint} ->
         endpoint = resolve_endpoint_sufix(endpoint)
 
-        build_final_endpoint([metadata.endpoint_prefix, endpoint], build_options)
+        build_final_endpoint(
+          [to_string(metadata[:host_prefix]) <> metadata.endpoint_prefix, endpoint],
+          build_options
+        )
 
       %{endpoint: endpoint} ->
         endpoint = resolve_endpoint_sufix(endpoint)
 
-        build_final_endpoint([metadata.endpoint_prefix, client.region, endpoint], build_options)
+        build_final_endpoint(
+          [
+            to_string(metadata[:host_prefix]) <> metadata.endpoint_prefix,
+            client.region,
+            endpoint
+          ],
+          build_options
+        )
     end
   end
 
@@ -208,7 +218,14 @@ defmodule AWS.Request do
         parts
       end
 
-    Enum.join(parts, ".")
+    joined = Enum.join(parts, ".")
+
+    # TODO: handle more cases other than `AccountId`
+    if options[:account_id] do
+      joined |> String.replace("{AccountId}", options.account_id, global: true)
+    else
+      joined
+    end
   end
 
   defp build_uri(%Client{} = client, host, path \\ "/") do

--- a/test/aws/request_test.exs
+++ b/test/aws/request_test.exs
@@ -210,5 +210,52 @@ defmodule AWS.RequestTest do
       assert {:unexpected_response,
               %{body: "{\"Response\":\"foo\"}", headers: [], status_code: 206}} = error
     end
+
+    test "send get request with host prefix", %{client: client, metadata: metadata} do
+      assert {:ok, _response, _http_response} =
+               Request.request_rest(
+                 client,
+                 Map.put(metadata, :host_prefix, "my-prefix."),
+                 :get,
+                 "/foo/bar",
+                 [{"q", "x&y="}, {"size", 5}],
+                 [],
+                 nil,
+                 [],
+                 nil
+               )
+
+      assert_receive {:request, :get, url, body, _headers, _options}
+
+      assert body == ""
+
+      assert url ==
+               "https://my-prefix.mobileanalytics.us-east1.amazonaws.com/foo/bar?q=x%26y%3D&size=5"
+    end
+
+    test "send get request with host prefix with account id", %{
+      client: client,
+      metadata: metadata
+    } do
+      assert {:ok, _response, _http_response} =
+               Request.request_rest(
+                 client,
+                 Map.put(metadata, :host_prefix, "{AccountId}-foo."),
+                 :get,
+                 "/foo/bar",
+                 [{"q", "x&y="}, {"size", 5}],
+                 [{"x-amz-account-id", "425211"}],
+                 nil,
+                 [],
+                 nil
+               )
+
+      assert_receive {:request, :get, url, body, _headers, _options}
+
+      assert body == ""
+
+      assert url ==
+               "https://425211-foo.mobileanalytics.us-east1.amazonaws.com/foo/bar?q=x%26y%3D&size=5"
+    end
   end
 end


### PR DESCRIPTION
This makes services that need `host_prefix` to work. It also replaces
`AccountId` if the host prefix needs it.