### PR TITLE
Relax `finch` version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule AWS.Mixfile do
       {:earmark, "~> 1.4", only: [:dev]},
       {:ex_doc, "~> 0.24", only: [:dev]},
       {:bypass, "~> 2.1", only: [:test]},
-      {:finch, "~> 0.13.0 or ~> 0.14.0", optional: true},
+      {:finch, "~> 0.13", optional: true},
       {:hackney, "~> 1.16", optional: true}
     ]
   end


### PR DESCRIPTION
The version requirement for `finch` is overly strict and prevents apps from upgrading to the latest version. Alternatively, we could add `or ~> 0.15.0` to the existing version string but this would mean that every time a new version of finch is released then a new version of `aws-elixir` would need to be released as well. Thanks!