### PR TITLE
Allow call-site specification of http client options.

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -194,8 +194,9 @@ defmodule AWS.Client do
     %{client | http_client: http_client}
   end
 
-  def request(client, method, url, body, headers, _opts \\ []) do
+  def request(client, method, url, body, headers, opts \\ []) do
     {mod, options} = Map.fetch!(client, :http_client)
+    options = Keyword.merge(options, opts)
     apply(mod, :request, [method, url, body, headers, options])
   end
 

--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -83,6 +83,7 @@ defmodule AWS.Request do
       |> to_string()
 
     {send_body_as_binary?, options} = Keyword.pop(options, :send_body_as_binary?)
+    {receive_body_as_binary?, options} = Keyword.pop(options, :receive_body_as_binary?)
 
     # It will assume the default as "application/octet-stream" if is sending body
     # as binary and the input does not specify the `Content-type`.
@@ -130,8 +131,6 @@ defmodule AWS.Request do
              status_code == success_status_code ->
         body =
           if body != "" do
-            {receive_body_as_binary?, _options} = Keyword.pop(options, :receive_body_as_binary?)
-
             response_body =
               if receive_body_as_binary? do
                 %{"Body" => body}


### PR DESCRIPTION
Hi,

This PR allows callsite specification of HTTP options like: `Lambda.invoke(..., recv_timeout: 30_000)`.
The tests passes, but I don't _really_ understand the implications of this change, so a smart maintainer should consider this carefully before merging..