### PR TITLE
chore: Add docs for multipart upload to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note that you may need to specify the `ContentType` attribute when calling `AWS.
 This is because S3 will use that to store the MIME type of the file.
 
 You can also upload to S3 as multipart. If you're facing timeout issues, this strategy is
-recommended.
+recommended:
 
 ```elixir
 client = AWS.Client.create("your-access-key-id", "your-secret-access-key", "us-east-1")
@@ -56,7 +56,7 @@ filename = "./your-big-file.wav"
 # AWS minimum chunk size is 5MB
 chunk_size = 5_242_880
 
-# Create the Multipart upload
+# Create the multipart request
 {:ok,
  %{
    "InitiateMultipartUploadResult" => %{


### PR DESCRIPTION
I decided to add this documentation example with a simple file, since S3 multipart uploads are probably very common and not very intuitive to do (if you're not familiar with the AWS API itself).

I had a lot of trouble trying to make this work, so maybe this example can help other people :)

Thanks to @dmorn and @onno-vos-dev for providing most of what I used in this example (and what I used to fix the issue I had in the first place) here: https://github.com/aws-beam/aws-elixir/issues/84