### PR TITLE
Increase :timer.sleep/1 in client_tests to avoid race conditions in Github Actions

### DIFF
--- a/test/aws/client_test.exs
+++ b/test/aws/client_test.exs
@@ -62,7 +62,7 @@ defmodule AWS.ClientTest do
 
     test "overrides config request options with call options", %{client: client, bypass: bypass} do
       Bypass.expect_once(bypass, "GET", "/timeout", fn conn ->
-        :timer.sleep(20)
+        :timer.sleep(200)
         Plug.Conn.resp(conn, 200, "")
       end)
 


### PR DESCRIPTION
I suspect this is the reason that: https://github.com/aws-beam/aws-elixir/actions/runs/7931827240 is failing