### PR TITLE
Automatic retries

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -197,22 +197,28 @@ defmodule AWS.Client do
   @doc """
   Makes a HTTP request using the specified client.
 
-  `opts` may contain the keyword `:enable_retries?` that enables request retries on known
-  errors such as 500s.
-  The keyword `:retry_opts` can further supply the arguments: `:max_retries`, `:base_sleep_time` &
-  `:cap_sleep_time` that control the retry mechanism. This uses exponential backoff with jitter to
-  sleep in between retry attempts. Default values are:
-  `retry_opts: [max_retries: 10, base_sleep_time: 5, cap_sleep_time: 5_000]`
+  ## Retries and options.
+  The option `:enable_retries?` enables request retries on known errors such as 500s.
+
+  * `enable_retries?` - Defaults to `false`.
+  * `retry_opts` - the options to configure retries in case of errors. This uses exponential backoff with jitter.
+    * `:max_retries` - the maximum number of retries (plus the initial request). Defaults to `10`.
+    * `:base_sleep_time` - the base sleep time in milliseconds. Defaults to `5`.
+    * `:cap_sleep_time`  - the maximum sleep time between atttempts. Defaults to `5_000`.
 
   See "FullJitter" at: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
-  ### Examples
+  ## Examples
 
       iex> AWS.Client.request(client, :post, url, payload, headers, options)
       {:ok, %{status_code: 200, body: body}}
 
       iex> AWS.Client.request(client, :post, url, payload, headers, enable_retries?: true)
       {:ok, %{status_code: 200, body: body}}
+
+      iex> AWS.Client.request(client, :post, url, payload, headers, enable_retries?: true, retry_opts: [max_retries: 3])
+      {:ok, %{status_code: 200, body: body}}
+
   """
   def request(client, method, url, body, headers, opts \\ []) do
     # Pop off all retry-related options from opts, so they aren't passed to the HTTP client.

--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -282,11 +282,16 @@ defmodule AWS.Client do
     end
   end
 
+  # Retry on 500
   defp retriable?({:ok, %{status_code: status}}) when status >= 500, do: :retry
-  # These are Hackney specific:
+  # Hackney specific
   defp retriable?({:error, :closed}), do: :retry
   defp retriable?({:error, :connect_timeout}), do: :retry
   defp retriable?({:error, :checkout_timeout}), do: :retry
+  # Finch/Mint specific
+  defp retriable?({:error, %{reason: :closed}}), do: :retry
+  defp retriable?({:error, %{reason: :timeout}}), do: :retry
+  # Do not retry on other erors
   defp retriable?({:error, _}), do: :error
   defp retriable?({:ok, _}), do: :ok
   defp retriable?({:ok, _, _}), do: :ok


### PR DESCRIPTION
Adds retries on 500, and a few Hackney specific errors.
Retries are not enabled unless the `retry_opts` option is given to the request:
```
AWS.Client.request(..., retry_opts: [max_retries: 3, base_sleep_time: 10, cap_sleep_time: 1000])
```
I don't fully understand the implications of enabling it by default, hence the caution here.