### PR TITLE
adds 'member' to map/list members

### DIFF
--- a/lib/aws/util.ex
+++ b/lib/aws/util.ex
@@ -36,11 +36,11 @@ defmodule AWS.Util do
 
       iex> input = %{"Action" => "OperationName", "Bar" => ["val1", "val2"], "Foo" => 42}
       iex> AWS.Util.encode_query(input)
-      "Action=OperationName&Bar.1=val1&Bar.2=val2&Foo=42"
+      "Action=OperationName&Bar.member.1=val1&Bar.member.2=val2&Foo=42"
 
       iex> input = %{"Action" => "OperationName", "Bar" => %{"Baz" => ["val1", "val2"]}, "Foo" => 42}
       iex> AWS.Util.encode_query(input)
-      "Action=OperationName&Bar.Baz.1=val1&Bar.Baz.2=val2&Foo=42"
+      "Action=OperationName&Bar.Baz.member.1=val1&Bar.Baz.member.2=val2&Foo=42"
 
   """
   def encode_query(input) do
@@ -54,7 +54,7 @@ defmodule AWS.Util do
     value
     |> Enum.with_index(1)
     |> Enum.map(fn {inner_value, idx} ->
-      encode_query_value({[key, ?., to_string(idx)], inner_value})
+      encode_query_value({[key, ?., "member", ?., to_string(idx)], inner_value})
     end)
   end
 

--- a/test/aws/util_test.exs
+++ b/test/aws/util_test.exs
@@ -35,7 +35,7 @@ defmodule AWS.UtilTest do
       }
 
       assert Util.encode_query(input) ==
-               "Action=OperationName&Operations.1=foo&Operations.2=bar"
+               "Action=OperationName&Operations.member.1=foo&Operations.member.2=bar"
     end
 
     test "with a map with string values" do
@@ -59,7 +59,7 @@ defmodule AWS.UtilTest do
       }
 
       assert Util.encode_query(input) ==
-               "Action=OperationName&Operation.1.name=foo&Operation.1.state=bar&Operation.2.name=baz&Operation.2.state=full&Operation.3.other.1=a&Operation.3.other.2=b&Operation.3.other.3=c"
+               "Action=OperationName&Operation.member.1.name=foo&Operation.member.1.state=bar&Operation.member.2.name=baz&Operation.member.2.state=full&Operation.member.3.other.member.1=a&Operation.member.3.other.member.2=b&Operation.member.3.other.member.3=c"
     end
   end
 end


### PR DESCRIPTION
without `member` keyword between the parameters and the numbers, I got following error
```
{:error,
 {:unexpected_response,
  %{
    body: "<ErrorResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>MalformedInput</Code>\n    <Message>Top level element may not be treated as a list</Message>\n  </Error>\n  <RequestId>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</RequestId>\n</ErrorResponse>\n",
    headers: [
      {"x-amzn-RequestId", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
      {"Content-Type", "text/xml"},
      {"Content-Length", "298"},
      {"Date", "Fri, 01 Nov 2024 07:54:27 GMT"},
      {"Connection", "close"}
    ],
    status_code: 400
  }}}
```