### PR TITLE
Fixes dialyzer error due to proplist and Keyword incompatibility

### DIFF
--- a/lib/aws/http_client/hackney.ex
+++ b/lib/aws/http_client/hackney.ex
@@ -12,7 +12,8 @@ defmodule AWS.HTTPClient.Hackney do
   def request(method, url, body, headers, options) do
     ensure_hackney_running!()
 
-    options = [:with_body | options] |> Keyword.put_new(:pool, @hackney_pool_name)
+    options = Keyword.put_new(options, :pool, @hackney_pool_name)
+    options = [:with_body | options]
 
     case :hackney.request(method, url, headers, body, options) do
       {:ok, status_code, response_headers, body} ->


### PR DESCRIPTION
`AWS.HTTPClient.Hackney.request/5` has a type error in the implementation which causes dialyzer to fail:

```
lib/aws/http_client/hackney.ex:12:no_return
Function request/5 has no local return.
```

`Keyword` always expects items to be of the form `{key(), value()}`. However, the code is including item `:with_body`, in the style of `t:proplists.proplist/0`.

Changing the order of execution resolves the typing issue.