### PR TITLE
feat: Allow option `sign_request?` to disable signing

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -124,11 +124,12 @@ defmodule AWS.Request do
     {sign_request?, options} = Keyword.pop(options, :sign_request?, true)
     # Most requests require signatures, but this option allows it to
     # be disabled.
-    headers = if sign_request? do
-      Signature.sign_v4(client, now(), http_method, url, headers, payload)
-    else
-      headers
-    end
+    headers =
+      if sign_request? do
+        Signature.sign_v4(client, now(), http_method, url, headers, payload)
+      else
+        headers
+      end
 
     {response_header_parameters, options} = Keyword.pop(options, :response_header_parameters)
 

--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -121,7 +121,14 @@ defmodule AWS.Request do
 
     headers = add_headers(additional_headers, headers)
 
-    headers = Signature.sign_v4(client, now(), http_method, url, headers, payload)
+    {sign_request?, options} = Keyword.pop(options, :sign_request?, true)
+    # Most requests require signatures, but this option allows it to
+    # be disabled.
+    headers = if sign_request? do
+      Signature.sign_v4(client, now(), http_method, url, headers, payload)
+    else
+      headers
+    end
 
     {response_header_parameters, options} = Keyword.pop(options, :response_header_parameters)
 


### PR DESCRIPTION
Thank you for this library. I’m not sure if this is the most effective way to implement this or if this type of change is wanted.

**Note: These API endpoints don't require a signed request (see at the bottom a curl command).**

This came up when I was testing out `AWS.SSOOIDC.register_client/3` and noticed I would get failures like `** (FunctionClauseError) no function clause matching in :aws_signature.sign_v4/10` with the below sample code.

I also think this a change like this is required for all four api calls for `AWS.SSOOIDC.(create_token|create_token_with_iam|register_client|start_device_authorization)`

```
client = %AWS.Client{region: "us-east-2"}
AWS.SSOOIDC.register_client(client, %{"clientName" => "elixir",
"clientType" => "public"})
```

With these changes I can now:

```
client = %AWS.Client{region: "us-east-2"}
AWS.SSOOIDC.register_client(client, %{"clientName" => "elixir",
"clientType" => "public"}, [sign_request?: false])

{:ok,
 %{
   "authorizationEndpoint" => nil,
   "clientId" => "clientId",
   "clientIdIssuedAt" => 1744683394,
   "clientSecret" => "clientSecret",
   "clientSecretExpiresAt" => 1752459394,
   "tokenEndpoint" => nil
 },
 %{
   body: "{\"authorizationEndpoint\":null,\"clientId\":\"clientId\",\"clientIdIssuedAt\":1744683394,\"clientSecret\":\"clientSecret\",\"clientSecretExpiresAt\":1752459394,\"tokenEndpoint\":null}",
   headers: [
     {"Date", "Tue, 15 Apr 2025 02:16:34 GMT"},
     {"Content-Type", "application/json"},
     {"Content-Length", "1775"},
     {"Connection", "keep-alive"},
     {"x-amzn-RequestId", "d5b94970-1246-4f7b-88b0"}
   ],
   status_code: 200
 }}
```

More information at
https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_RegisterClient.html

Showing that these apis don't need a signed request:
```
curl -X POST https://oidc.us-east-2.amazonaws.com/client/register -d '{"clientName": "my-client", "clientType": "public"}'
```