### PR TITLE
DELETE requests have no body

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -101,7 +101,7 @@ defmodule AWS.Request do
         send_body_as_binary? ->
           Map.fetch!(input, "Body")
 
-        http_method in [:get, :head, :options] ->
+        http_method in [:get, :head, :options, :delete] ->
           ""
 
         true ->


### PR DESCRIPTION
Attempting to use `AWS.Lambda.delete_function` results in a `InvalidSignatureException` from AWS. This PR resolves the issue.