### PR TITLE
Allow retrying on http 429 too many requests

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -282,8 +282,8 @@ defmodule AWS.Client do
     end
   end
 
-  # Retry on 500
-  defp retriable?({:ok, %{status_code: status}}) when status >= 500, do: :retry
+  # Retry on 500 or 429
+  defp retriable?({:ok, %{status_code: status}}) when status >= 500 or status == 429, do: :retry
   # Hackney specific
   defp retriable?({:error, :closed}), do: :retry
   defp retriable?({:error, :connect_timeout}), do: :retry


### PR DESCRIPTION
When generating an AWS SSO config [1], you can quickly get HTTP 429 errors. This change allows for retrying.

[1] https://github.com/djgoku/aws-sso-config-generator

